### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/beer_recognition_api/run.py
+++ b/beer_recognition_api/run.py
@@ -77,7 +77,7 @@ def main():
     print(f'Version: {get_version()}')
     print(f'Base URL: http://localhost:{config.PORT}{config.URL_PREFIX}')
     print(separator_str)
-    app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE)
+    app.run(host=config.HOST, port=config.PORT)
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/iSkYrIsE/beer-recognition-api/security/code-scanning/2](https://github.com/iSkYrIsE/beer-recognition-api/security/code-scanning/2)

In general, the problem is fixed by ensuring the built-in Flask development server is never started in debug mode in production code. Instead, debug mode should either be limited to explicit local-development entry points or disabled entirely when calling `app.run()` from a reusable module.

For this specific file, the safest fix that does not change existing functional behavior of the API itself is to stop wiring the `config.DEBUG_MODE` setting into `app.run()`. We can still log the configured debug mode for informational purposes, but the actual call to `app.run` should not enable the Werkzeug debugger. The minimal, non-invasive change is to remove the `debug` argument from the `app.run` call so it defaults to `False`. This ensures that even if `config.DEBUG_MODE` is accidentally set to `True`, the Werkzeug debugger will not be activated via this script.

Concretely:
- Edit `beer_recognition_api/run.py` in the `main()` function.
- Replace line 80, `app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE)`, with a call that omits the `debug` parameter: `app.run(host=config.HOST, port=config.PORT)`.
- No new imports or helper methods are required; we simply alter the arguments to `app.run`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
